### PR TITLE
Fix propogation bug

### DIFF
--- a/APD.cu
+++ b/APD.cu
@@ -1084,7 +1084,7 @@ __device__ void CheckerboardPropagationStrong(
 		for (int i = 1; i < 11; ++i) {
 			if (p.x < width - 3 - 2 * i) {
 				int pointTemp = right_far + 2 * i;
-				if (costMin < costs[pointTemp]) {
+				if (costs[pointTemp] < costMin) {
 					costMin = costs[pointTemp];
 					costMinPoint = pointTemp;
 				}


### PR DESCRIPTION
Fix `costMin` comparison for `right_far` propagation. Same bug is present in ACMM and ACMMP.